### PR TITLE
feat: Add apiserver and webui

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ The docker-compose file spins up a complete monitoring and database stack with t
 > [!WARNING]  
 > These services are only for local testing, if run productively change default passwords!
 
-| Service        | Port  | URL                    | Username            | Password           | Description                                                 |
-| -------------- | ----- | ---------------------- | ------------------- | ------------------ | ----------------------------------------------------------- |
-| **Grafana**    | 3000  | http://localhost:3000  | `admin`             | `admin`            | Dashboards & Visualization                                  |
-| **Prometheus** | 9090  | http://localhost:9090  | -                   | -                  | Metrics Collection                                          |
-| **Loki**       | 3100  | http://localhost:3100  | -                   | -                  | Log Aggregation                                             |
-| **Alloy**      | 12345 | http://localhost:12345 | -                   | -                  | Log Collection Agent                                        |
-| **cAdvisor**   | 8080  | http://localhost:8080  | -                   | -                  | Container Metrics                                           |
-| **pgAdmin**    | 5050  | http://localhost:5050  | `admin@example.com` | `admin`            | PostgreSQL Web Interface (use pg password to add DB server) |
-| **PostgreSQL** | 5432  | `localhost:5432`       | `enclave_user`      | `enclave_password` | Meta Database                                               |
-| **Redis**      | 6379  | `localhost:6379`       | -                   | -                  | Queue                                                       |
+| Service                      | Port  | URL                    | Username            | Password           | Description                                                 |
+| ---------------------------- | ----- | ---------------------- | ------------------- | ------------------ | ----------------------------------------------------------- |
+| **Grafana**                  | 3000  | http://localhost:3000  | `admin`             | `admin`            | Dashboards & Visualization                                  |
+| **Prometheus**               | 9090  | http://localhost:9090  | -                   | -                  | Metrics Collection                                          |
+| **Loki**                     | 3100  | http://localhost:3100  | -                   | -                  | Log Aggregation                                             |
+| **Alloy**                    | 12345 | http://localhost:12345 | -                   | -                  | Log Collection Agent                                        |
+| **cAdvisor**                 | 8080  | http://localhost:8080  | -                   | -                  | Container Metrics                                           |
+| **pgAdmin**                  | 5050  | http://localhost:5050  | `admin@example.com` | `admin`            | PostgreSQL Web Interface (use pg password to add DB server) |
+| **PostgreSQL**               | 5432  | `localhost:5432`       | `enclave_user`      | `enclave_password` | Meta Database                                               |
+| **Redis**                    | 6379  | `localhost:6379`       | -                   | -                  | Queue                                                       |
+| **Web UI (Enclave Console)** | 8083  | http://localhost:8083  | - enclave           | - enclave          | Graphical management console for the enclave plattform      |

--- a/docker-compose/api-server.yaml
+++ b/docker-compose/api-server.yaml
@@ -1,0 +1,14 @@
+port: 8080
+log_level: debug
+production_environment: true
+human_readable_output: true
+database:
+  host: postgres
+  port: 5432
+  user: enclave_user
+  password: enclave_password
+  database: enclave_db
+admin:
+  username: enclave
+  display_name: System
+  password: enclave

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -141,5 +141,31 @@ services:
     networks:
       - internal
 
+  api-server:
+    image: ghcr.io/enclaverunner/api-server:0.3.1
+    container_name: api-server
+    restart: unless-stopped
+    volumes:
+      - ./api-server.yaml:/etc/enclave/config.yaml
+    expose:
+      - 8081
+    ports:
+      - 8081:8080
+    networks:
+      - internal
+    depends_on:
+      - postgres
+
+  web-ui:
+    image: ghcr.io/enclaverunner/web-ui:0.1
+    container_name: web-ui
+    ports:
+      - "8083:8091"
+    environment:
+      - API_BASE_URL=api-server
+      - API_PORT=8080
+    networks:
+      - internal
+
 networks:
   internal:


### PR DESCRIPTION
This PR adds a container for the api-server and web-ui images from the github oci image registry. The versions are currently pinned to the latest version as of opening this PR (Web UI V0.1, API Server V0.3.1)